### PR TITLE
accept encoding parameter to use when opening the input file

### DIFF
--- a/tkseem/_base.py
+++ b/tkseem/_base.py
@@ -16,7 +16,7 @@ class BaseTokenizer:
     """
 
     def __init__(
-        self, unk_token="<UNK>", pad_token="<PAD>", vocab_size=10000, special_tokens=[],
+        self, unk_token="<UNK>", pad_token="<PAD>", vocab_size=10000, special_tokens=[], encoding=None,
     ):
         """Constructor
 
@@ -30,6 +30,7 @@ class BaseTokenizer:
         self.unk_token = unk_token
         self.pad_token = pad_token
         self.special_tokens = special_tokens
+        self.encoding = encoding
         self.rel_path = os.path.dirname(__file__)
         cach_dict_path = os.path.join(self.rel_path, "dictionaries/cached.pl")
         self.cached = pickle.load(open(cach_dict_path, "rb"))
@@ -74,7 +75,7 @@ class BaseTokenizer:
         Returns:
             dict : dict containing frequency
         """
-        text = open(file_path, "r").read()
+        text = open(file_path, "r", encoding=self.encoding).read()
         tokens_frequency = defaultdict(int)
         for word in text.split(" "):
             tokens_frequency[word] += 1
@@ -391,7 +392,7 @@ class BaseTokenizer:
             encodings[i] = self.pad(encodings[i], max_length)[:out_length]
             if encodings[i][-1] != pad_id and boundries:
                 encodings[i][-1] = self.token_to_id(boundries[1])
-        
+
         return np.array(encodings)
 
     def load_model(self, file_path):

--- a/tkseem/bruteforce_tokenizer.py
+++ b/tkseem/bruteforce_tokenizer.py
@@ -16,9 +16,9 @@ class BruteForceTokenizer(BaseTokenizer):
         Args:
             file_path (str): file to train 
         """
-        
+
         print("Training RandomTokenizer ...")
-        text = open(file_path, "r").read()
+        text = open(file_path, "r", encoding=self.encoding).read()
         self.vocab = self._truncate_dict(self._bruteforce_dict(text))
         self.vocab_size = len(self.vocab)
 

--- a/tkseem/character_tokenizer.py
+++ b/tkseem/character_tokenizer.py
@@ -18,7 +18,7 @@ class CharacterTokenizer(BaseTokenizer):
         print("Training CharacterTokenizer ...")
         rx = re.compile(r"\B(.)")
 
-        text = open(file_path, "r").read()
+        text = open(file_path, "r", encoding=self.encoding).read()
         text = rx.sub(r" ##\1", text)
 
         tokens_frequency = defaultdict(int)

--- a/tkseem/disjoint_letters_tokenizer.py
+++ b/tkseem/disjoint_letters_tokenizer.py
@@ -18,7 +18,7 @@ class DisjointLetterTokenizer(BaseTokenizer):
         print("Training DisjointLetterTokenizer ...")
         rx = re.compile(r"([اأإآءؤﻵﻹﻷدذرزو])")
 
-        text = open(file_path, "r").read()
+        text = open(file_path, "r", encoding=self.encoding).read()
         text = rx.sub(r"\1## ", text)
         text = text.replace("## ", " ##")
 

--- a/tkseem/morphological_tokenizer.py
+++ b/tkseem/morphological_tokenizer.py
@@ -11,4 +11,4 @@ class MorphologicalTokenizer(BaseTokenizer):
         """Use a default dictionary for training"""
         print("Training MorphologicalTokenizer ...")
         vocab_path = os.path.join(self.rel_path, "dictionaries/vocab.pl")
-        self.vocab = self._truncate_dict(pickle.load(open(vocab_path, "rb")))
+        self.vocab = self._truncate_dict(pickle.load(open(vocab_path, "rb", encoding=self.encoding)))

--- a/tkseem/random_tokenizder.py
+++ b/tkseem/random_tokenizder.py
@@ -18,7 +18,7 @@ class RandomTokenizer(BaseTokenizer):
         """
         
         print("Training RandomTokenizer ...")
-        text = open(file_path, "r").read()
+        text = open(file_path, "r", encoding=self.encoding).read()
         self.vocab = self._truncate_dict(self._random_dict(text))
         self.vocab_size = len(self.vocab)
 


### PR DESCRIPTION
## What I did
I added the `encoding` argument to the `BaseTokenizer` constructor.
This parameter is used when opening the input file in the tokenizers implementations.

## Use Case
I needed this when running on Windows (which uses `cp1252` as encoding as default), and was getting this error
```
'charmap' codec can't encode characters in position 0-6: character maps to <undefined>
```

#### Note
The only tokenizer I didn't edit is the `SentencePieceTokenizer`, since it uses a separate package.
Might be a good idea to have a warning if the `encoding` parameter is specified. Something like:
```
Warning: the "encoding" parameter is ignored in SentencePieceTokenizer
```